### PR TITLE
perf: reduce logging by 96% (51 debug logs removed)

### DIFF
--- a/src/main/kotlin/dev/hytalemodding/newnet/BlockChangeEventSystems.kt
+++ b/src/main/kotlin/dev/hytalemodding/newnet/BlockChangeEventSystems.kt
@@ -120,12 +120,10 @@ class PowerBlockAddedSystem : RefSystem<ChunkStore>() {
                 }
             }
             if (foundDriverFace == null) {
-                println("[PowerBlockAddedSystem] InputPort at $pos has no adjacent PowerSource, Relay, or complete MUX, destroying")
                 world.execute { world.setBlock(pos.x, pos.y, pos.z, "Empty") }
                 return
             }
             inputPort.driverSideFace = foundDriverFace
-            println("[PowerBlockAddedSystem] InputPort at $pos configured: driverSide=${FACE_NAMES[foundDriverFace]}")
         }
 
         // If this block is a Mux2Part, handle pairing logic
@@ -154,13 +152,11 @@ class PowerBlockAddedSystem : RefSystem<ChunkStore>() {
                 // Lever defaults to isOn=false, so set PowerSource to ONE initially (inverted)
                 powerSource.driveState = if (lever.isOn) State4.ZERO else State4.ONE
                 powerSource.lastDriveState = powerSource.driveState
-                println("[PowerBlockAddedSystem] Lever at $pos initialized: isOn=${lever.isOn}, driveState=${powerSource.driveState}")
             }
         }
 
         val queue = store.getResource(ExamplePlugin.stateChangeQueueType)
         queue.changes.add(StateChangeEvent(pos, StateChangeKind.PLACED))
-        println("[PowerBlockAddedSystem] Queued PLACED at (${pos.x}, ${pos.y}, ${pos.z}), queue size: ${queue.changes.size}")
 
         // If this block is a wire, mark it + neighbors for wire shape update
         val hasPowerWire = cmdBuf.getComponent(ref, ExamplePlugin.powerWireComponentType) != null
@@ -171,7 +167,6 @@ class PowerBlockAddedSystem : RefSystem<ChunkStore>() {
                     Vector3i(pos.x + FACE_DX[face], pos.y + FACE_DY[face], pos.z + FACE_DZ[face])
                 )
             }
-            println("[PowerBlockAddedSystem] Wire placed at $pos, marked ${queue.wireDirtyPositions.size} wire dirty positions")
         }
     }
 
@@ -245,7 +240,6 @@ class PowerBlockBreakEvent : EntityEventSystem<EntityStore, BreakBlockEvent>(Bre
 
         val queue = world.chunkStore.store.getResource(ExamplePlugin.stateChangeQueueType)
         queue.changes.add(StateChangeEvent(pos, StateChangeKind.DESTROYED))
-        println("[PowerBlockBreakEvent] Queued DESTROYED at (${pos.x}, ${pos.y}, ${pos.z}), queue size: ${queue.changes.size}")
 
         // If this block is a wire, mark neighbors for wire shape update
         val hasPowerWire = worldAccess.getComponent(pos, ExamplePlugin.powerWireComponentType) != null
@@ -255,7 +249,6 @@ class PowerBlockBreakEvent : EntityEventSystem<EntityStore, BreakBlockEvent>(Bre
                     Vector3i(pos.x + FACE_DX[face], pos.y + FACE_DY[face], pos.z + FACE_DZ[face])
                 )
             }
-            println("[PowerBlockBreakEvent] Wire broken at $pos, marked neighbors for wire shape update")
         }
     }
 

--- a/src/main/kotlin/dev/hytalemodding/newnet/LeverInteractionSystem.kt
+++ b/src/main/kotlin/dev/hytalemodding/newnet/LeverInteractionSystem.kt
@@ -47,7 +47,6 @@ class LeverInteractionSystem : EntityEventSystem<EntityStore, UseBlockEvent.Post
 
         // Toggle the lever state
         lever.isOn = !lever.isOn
-        println("[LeverInteractionSystem] Toggled lever at $pos to ${if (lever.isOn) "ON" else "OFF"}")
 
         // Update PowerSource driveState based on new toggle state
         // OFF → ONE, ON → ZERO (inverted because PowerSource is an inverting gate)
@@ -61,7 +60,6 @@ class LeverInteractionSystem : EntityEventSystem<EntityStore, UseBlockEvent.Post
         // Mark visual state dirty for VisualStateSystem to update appearance
         queue.visualDirtyPositions.add(pos)
         
-        println("[LeverInteractionSystem] Queued topology update and visual refresh for $pos")
     }
 
     override fun getQuery(): Query<EntityStore> = Query.and(Player.getComponentType())

--- a/src/main/kotlin/dev/hytalemodding/newnet/Mux2Control.kt
+++ b/src/main/kotlin/dev/hytalemodding/newnet/Mux2Control.kt
@@ -98,7 +98,6 @@ fun evaluateMuxSelect(
         State4.HIGH_Z
     }
 
-    println("[MUX-S] probe at $probePos face=$probeFace netId=$netId value=$netValue (IP at $npos, driverSide=${inputPort.driverSideFace})")
 
     return when (netValue) {
         State4.ZERO -> Triple(0, false, false)      // S=0 → select A
@@ -184,7 +183,6 @@ fun evaluateAllMuxControls(
         val routingChanged = (mux.selectedInput != mux.lastSelectedInput) ||
                 (mux.isDisconnected != mux.lastIsDisconnected)
         if (routingChanged) {
-            println("[Mux2Control] MUX at $pos/$pairedPos routing changed: select=$selectedInput, disconnected=$isDisconnected, fault=$controlFault")
             anyToggled = true
         }
     }

--- a/src/main/kotlin/dev/hytalemodding/newnet/Mux2PlacementSystem.kt
+++ b/src/main/kotlin/dev/hytalemodding/newnet/Mux2PlacementSystem.kt
@@ -49,13 +49,11 @@ fun tryPairMux(pos: Vector3i, mux: Mux2Part, worldAccess: WorldAccess): Boolean 
             mux.pairFace = face
             mux.isComplete = true
             mux.isDisconnected = neighborMux.isDisconnected
-            println("[Mux2Placement] MUX at $pos synced with existing pair at $npos (world load recovery)")
             return true
         }
 
         if (neighborMux.isComplete) {
             // Neighbor is already in a complete pair with someone else — can't attach to it
-            println("[Mux2Placement] MUX at $pos can't pair: neighbor at $npos already complete")
             continue
         }
 
@@ -70,7 +68,6 @@ fun tryPairMux(pos: Vector3i, mux: Mux2Part, worldAccess: WorldAccess): Boolean 
         neighborMux.isComplete = true
         neighborMux.isDisconnected = true
 
-        println("[Mux2Placement] MUX pair formed: $pos <-> $npos (axis: ${FACE_NAMES[face]})")
         return true
     }
 
@@ -78,7 +75,6 @@ fun tryPairMux(pos: Vector3i, mux: Mux2Part, worldAccess: WorldAccess): Boolean 
     mux.isComplete = false
     mux.pairedPos = null
     mux.pairFace = -1
-    println("[Mux2Placement] MUX at $pos placed incomplete (no adjacent MUX)")
     return false
 }
 
@@ -99,19 +95,16 @@ fun shouldDestroyIncompleteMux(pos: Vector3i, worldAccess: WorldAccess): Boolean
         val neighborMux = worldAccess.getComponent(npos, ExamplePlugin.mux2PartComponentType)
         if (neighborMux != null) {
             if (neighborMux.isComplete) {
-                println("[Mux2Placement] Incomplete MUX at $pos adjacent to complete MUX at $npos — destroying")
                 return true
             }
             continue // Unpaired MUX neighbor is fine
         }
         // Check if neighbor is a PowerConnectable (wire, relay, lamp, source, etc.)
         if (worldAccess.getComponent(npos, ExamplePlugin.powerConnectableComponentType) != null) {
-            println("[Mux2Placement] Incomplete MUX at $pos has non-MUX connectable neighbor at $npos — destroying")
             return true
         }
         // Check if neighbor is an InputPort
         if (worldAccess.getComponent(npos, ExamplePlugin.inputPortComponentType) != null) {
-            println("[Mux2Placement] Incomplete MUX at $pos has InputPort neighbor at $npos — destroying")
             return true
         }
     }
@@ -140,11 +133,9 @@ fun handleMuxDestroyed(destroyedPos: Vector3i, worldAccess: WorldAccess) {
         pairedMux.pairFace = -1
         pairedMux.isDisconnected = true
         pairedMux.controlFault = false
-        println("[Mux2Placement] MUX pair broken: $destroyedPos destroyed, $pairedPos now incomplete")
 
         // Check if the now-incomplete block should also be destroyed
         if (shouldDestroyIncompleteMux(pairedPos, worldAccess)) {
-            println("[Mux2Placement] Remaining MUX at $pairedPos has invalid neighbors — scheduling destroy")
             if (worldAccess is HytaleWorldAccess) {
                 worldAccess.world.execute { worldAccess.world.setBlock(pairedPos.x, pairedPos.y, pairedPos.z, "Empty") }
             }

--- a/src/main/kotlin/dev/hytalemodding/newnet/Mux2Topology.kt
+++ b/src/main/kotlin/dev/hytalemodding/newnet/Mux2Topology.kt
@@ -123,7 +123,6 @@ fun getMuxConductionMask(pos: Vector3i, mux: Mux2Part, worldAccess: WorldAccess)
     val side = if (thisIsABlock) "A" else "B"
     val inputName = if (myInputFace != -1) faceNames.getOrElse(myInputFace) { "?" } else "NONE"
     val sel = if (myInputFace != -1 && mux.selectedInput == thisInputIndex) "CONDUCTS" else "ISOLATED"
-    println("[MUX-mask] $pos side=$side sel=${mux.selectedInput} input=$inputName($sel) pair=${faceNames.getOrElse(pairFace){"?"}} mask=0b${mask.toString(2).padStart(6,'0')}")
 
     return mask
 }

--- a/src/main/kotlin/dev/hytalemodding/newnet/RelayControl.kt
+++ b/src/main/kotlin/dev/hytalemodding/newnet/RelayControl.kt
@@ -129,7 +129,6 @@ fun evaluateAllRelayControls(
         relay.enabled = enabled
         relay.controlFault = controlFault
         if (relay.enabled != relay.lastEnabled) {
-            println("[RelayControl] Relay at $pos toggled: enabled=$enabled (was=${relay.lastEnabled}), controlFault=$controlFault")
             anyToggled = true
         }
     }

--- a/src/main/kotlin/dev/hytalemodding/newnet/TopologySystem.kt
+++ b/src/main/kotlin/dev/hytalemodding/newnet/TopologySystem.kt
@@ -335,7 +335,6 @@ fun clearNetsFromSeeds(seedBlocks: Set<Vector3i>, worldAccess: WorldAccess, queu
             }
         }
         if (clearedFaces.isNotEmpty()) {
-            println("[clearNets] Net $netId cleared: $clearedFaces")
         }
         // Remove from membership index (will be rebuilt in Phase 2)
         queue.removeNet(netId)
@@ -381,7 +380,6 @@ fun rebuildPowerTopology(dirtyBlocks: Set<Vector3i>, worldAccess: WorldAccess, q
             if (ids.get(face) != UNASSIGNED) continue
 
             val netId = queue.allocateNetId()
-            println("[rebuildTopology] New net $netId starting at $pos face=${FACE_NAMES[face]}")
             floodFillPower(pos, face, netId, worldAccess, queue)
         }
     }
@@ -431,7 +429,6 @@ fun floodFillPower(startPos: Vector3i, startFace: Int, netId: Int, worldAccess: 
         // Assign this face to the network
         ids.set(face, netId)
         queue.addNetMember(netId, pos, face)
-        println("[floodFill] Assign net $netId to $pos face=${FACE_NAMES[face]}")
 
         // Internal connectivity rule 1: PowerWire bridges all connectable faces
         val isWire = worldAccess.getComponent(pos, ExamplePlugin.powerWireComponentType) != null
@@ -439,7 +436,6 @@ fun floodFillPower(startPos: Vector3i, startFace: Int, netId: Int, worldAccess: 
             for (face2 in 0..5) {
                 if (face2 == face) continue  // Skip self
                 if (conn.facesMask and (1 shl face2) != 0 && ids.get(face2) == UNASSIGNED) {
-                    println("[floodFill]   Wire internal spread $pos ${FACE_NAMES[face]} -> ${FACE_NAMES[face2]}")
                     bfsQueue.add(Pair(pos, face2))
                 }
             }
@@ -457,7 +453,6 @@ fun floodFillPower(startPos: Vector3i, startFace: Int, netId: Int, worldAccess: 
                     val face2IsControl = controlMask and (1 shl face2) != 0
                     // Only spread to other conduction faces
                     if (!face2IsControl && conn.facesMask and (1 shl face2) != 0 && ids.get(face2) == UNASSIGNED) {
-                        println("[floodFill]   Relay internal spread $pos ${FACE_NAMES[face]} -> ${FACE_NAMES[face2]}")
                         bfsQueue.add(Pair(pos, face2))
                     }
                 }
@@ -475,11 +470,9 @@ fun floodFillPower(startPos: Vector3i, startFace: Int, netId: Int, worldAccess: 
                     if (conductionMask and (1 shl face2) == 0) continue
                     val existingNet = ids.get(face2)
                     if (existingNet == UNASSIGNED) {
-                        println("[floodFill]   MUX internal spread $pos ${FACE_NAMES[face]} -> ${FACE_NAMES[face2]}")
                         bfsQueue.add(Pair(pos, face2))
                     } else if (existingNet != netId) {
                         // Merge: reassign all members of existingNet to netId
-                        println("[floodFill]   MUX net merge at $pos ${FACE_NAMES[face2]}: net $existingNet -> $netId")
                         val members = queue.netMembers[existingNet]
                         if (members != null) {
                             for ((mPos, mFace) in members.toList()) {
@@ -500,7 +493,6 @@ fun floodFillPower(startPos: Vector3i, startFace: Int, netId: Int, worldAccess: 
         val nids = worldAccess.getComponent(npos, ExamplePlugin.powerNetIdsComponentType)
 
         if (nconn != null && nids != null && nconn.facesMask and (1 shl nface) != 0 && nids.get(nface) == UNASSIGNED) {
-            println("[floodFill]   External spread $pos ${FACE_NAMES[face]} -> neighbor $npos ${FACE_NAMES[nface]}")
             bfsQueue.add(Pair(npos, nface))
         }
 
@@ -514,7 +506,6 @@ fun floodFillPower(startPos: Vector3i, startFace: Int, netId: Int, worldAccess: 
                 val farConn = worldAccess.getComponent(farPos, ExamplePlugin.powerConnectableComponentType)
                 val farIds = worldAccess.getComponent(farPos, ExamplePlugin.powerNetIdsComponentType)
                 if (farConn != null && farIds != null && farConn.facesMask and (1 shl farNface) != 0 && farIds.get(farNface) == UNASSIGNED) {
-                    println("[floodFill]   MUX IP pass-through $pos -> IP $npos -> $farPos ${FACE_NAMES[farNface]}")
                     bfsQueue.add(Pair(farPos, farNface))
                 }
             }
@@ -534,7 +525,6 @@ fun floodFillPower(startPos: Vector3i, startFace: Int, netId: Int, worldAccess: 
                     if (muxMask and (1 shl muxNface) != 0) {
                         val muxIds = worldAccess.getComponent(muxPos, ExamplePlugin.powerNetIdsComponentType)
                         if (muxIds != null && muxIds.get(muxNface) == UNASSIGNED) {
-                            println("[floodFill]   MUX IP pass-through $pos -> IP $npos -> MUX $muxPos ${FACE_NAMES[muxNface]}")
                             bfsQueue.add(Pair(muxPos, muxNface))
                         }
                     }
@@ -647,13 +637,11 @@ fun evaluateSources(dirtyBlocks: Set<Vector3i>, worldAccess: WorldAccess, queue:
         if (lever != null) {
             // Lever state was already set by LeverInteractionSystem, don't overwrite
             source.lastDriveState = source.driveState
-            println("[evaluateSources] Lever at $pos: drive=${source.driveState} (manual control)")
             continue
         }
         
         source.lastDriveState = source.driveState
         source.driveState = computeInverterDrive(pos, worldAccess, queue)
-        println("[evaluateSources] Source at $pos: drive=${source.driveState} (was ${source.lastDriveState})")
     }
 }
 
@@ -732,7 +720,6 @@ fun destroyXNets(dirtyNetIds: Set<Int>, world: World, queue: StateChangeEventQue
     }
     if (positionsToDestroy.isEmpty()) return
 
-    println("[destroyXNets] Destroying ${positionsToDestroy.size} blocks on X nets")
     world.execute {
         for (pos in positionsToDestroy) {
             world.setBlock(pos.x, pos.y, pos.z, "Empty")
@@ -801,8 +788,6 @@ fun updateLamps(dirtyBlocks: Set<Vector3i>, worldAccess: WorldAccess, queue: Sta
         lamp.lit = lit
         setVisualState(pos, worldAccess, queue, if (lit) "On" else "default")
         if (faceNets.isNotEmpty()) {
-            println("[updateLamps] Lamp at $pos: nets=$faceNets, lit=$lit (was=$oldLit)" +
-                if (matchedFace != null) " powered via ${FACE_NAMES[matchedFace]}" else " no powered net")
         }
     }
 }
@@ -822,7 +807,6 @@ fun updateRelayVisuals(dirtyBlocks: Set<Vector3i>, worldAccess: WorldAccess, que
         val relay = worldAccess.getComponent(pos, ExamplePlugin.relayComponentType) ?: continue
         val newState = if (relay.enabled) "On" else "default"
         if (setVisualState(pos, worldAccess, queue, newState)) {
-            println("[updateRelayVisuals] Relay at $pos: enabled=${relay.enabled}, state=$newState")
         }
     }
 }
@@ -842,7 +826,6 @@ fun updateDriverVisuals(dirtyBlocks: Set<Vector3i>, worldAccess: WorldAccess, qu
         val source = worldAccess.getComponent(pos, ExamplePlugin.powerSourceComponentType) ?: continue
         val newState = if (source.driveState == State4.ONE) "On" else "default"
         if (setVisualState(pos, worldAccess, queue, newState)) {
-            println("[updateDriverVisuals] PowerSource at $pos: driveState=${source.driveState}, state=$newState")
         }
     }
 }
@@ -862,7 +845,6 @@ fun updateLeverVisuals(dirtyBlocks: Set<Vector3i>, worldAccess: WorldAccess, que
         val lever = worldAccess.getComponent(pos, ExamplePlugin.leverComponentType) ?: continue
         val newState = if (lever.isOn) "On" else "default"
         if (setVisualState(pos, worldAccess, queue, newState)) {
-            println("[updateLeverVisuals] Lever at $pos: isOn=${lever.isOn}, state=$newState")
         }
     }
 }
@@ -890,7 +872,6 @@ fun updateWireVisuals(dirtyBlocks: Set<Vector3i>, worldAccess: WorldAccess, queu
             }
         }
         if (setVisualState(pos, worldAccess, queue, if (powered) "On" else "default")) {
-            println("[updateWireVisuals] Wire at $pos: powered=$powered")
         }
     }
 }
@@ -920,7 +901,6 @@ fun updateInputPortVisuals(dirtyBlocks: Set<Vector3i>, worldAccess: WorldAccess,
         }
         val newState = if (netValue == State4.ONE) "On" else "default"
         if (setVisualState(pos, worldAccess, queue, newState)) {
-            println("[updateInputPortVisuals] InputPort at $pos: probeNet=$netId, value=$netValue, state=$newState")
         }
     }
 }
@@ -968,10 +948,8 @@ fun updateMuxVisuals(dirtyBlocks: Set<Vector3i>, worldAccess: WorldAccess, queue
         val nonSelectedBlockPos = if (mux.selectedInput == 0) bBlockPos else aBlockPos
 
         if (setVisualState(selectedBlockPos, worldAccess, queue, "On")) {
-            println("[updateMuxVisuals] MUX at $selectedBlockPos: ON (selected input ${mux.selectedInput})")
         }
         if (setVisualState(nonSelectedBlockPos, worldAccess, queue, "default")) {
-            println("[updateMuxVisuals] MUX at $nonSelectedBlockPos: OFF (not selected)")
         }
     }
 }
@@ -1045,7 +1023,6 @@ class TopologySystem : TickingSystem<ChunkStore>() {
         while (changesQueue.changes.isNotEmpty()) {
             val event = changesQueue.changes.removeFirst()
             seeds.add(event.pos)
-            println("[TopologySystem] Seed: ${event.pos} (${event.kind})")
         }
 
         val world = store.externalData.world
@@ -1062,7 +1039,6 @@ class TopologySystem : TickingSystem<ChunkStore>() {
 
         // Outer topology loop: handles relay-induced topology changes
         for (round in 0 until MAX_TOPOLOGY_ROUNDS) {
-            println("[TopologySystem] Topology round $round, seeds=${topologySeeds.size}")
 
             // Phase 3: Clear all nets touched by seed blocks
             var dirtyBlocks: Set<Vector3i> = clearNetsFromSeeds(topologySeeds, worldAccess, changesQueue)
@@ -1081,7 +1057,6 @@ class TopologySystem : TickingSystem<ChunkStore>() {
             }
 
             allDirtyBlocks.addAll(dirtyBlocks)
-            println("[TopologySystem] Round $round: ${topologySeeds.size} seed blocks -> ${dirtyBlocks.size} dirty blocks")
 
             // Reset all dirty relays to disabled before rebuilding topology (round 0 only).
             // This prevents stale relay state from merging nets and creating false feedback
@@ -1126,7 +1101,6 @@ class TopologySystem : TickingSystem<ChunkStore>() {
                         break
                     }
                 }
-                println("[TopologySystem] Delta cycle $cycle: stable=$stable")
             }
 
             // Phase 8: If not stable after MAX_DELTA_CYCLES, force all dirty nets to X
@@ -1167,7 +1141,6 @@ class TopologySystem : TickingSystem<ChunkStore>() {
                 }
             }
             topologySeeds = expandForInputPortDrivers(expandedToggled, worldAccess)
-            println("[TopologySystem] Relay/MUX toggled, re-seeding with ${topologySeeds.size} blocks for round ${round + 1}")
         }
 
         // If topology loop exhausted, force all accumulated nets to X
@@ -1191,7 +1164,6 @@ class TopologySystem : TickingSystem<ChunkStore>() {
         updateMuxVisuals(allDirtyBlocks, worldAccess, changesQueue)
 
         if (allDirtyNetIds.isNotEmpty()) {
-            println("[TopologySystem] Rebuilt: ${allDirtyBlocks.size} dirty blocks, ${allDirtyNetIds.size} nets, values: ${changesQueue.powerNetValueCache}")
         }
     }
 }

--- a/src/main/kotlin/dev/hytalemodding/newnet/VisualStateSystem.kt
+++ b/src/main/kotlin/dev/hytalemodding/newnet/VisualStateSystem.kt
@@ -65,7 +65,6 @@ private fun processWireShapeUpdates(queue: StateChangeEventQueue, world: World, 
         val blockId = BlockType.getAssetMap().getIndex(targetBlockTypeId)
         val blockType = BlockType.getAssetMap().getAsset(blockId) ?: continue
 
-        println("[WireShape] Swapping $pos from $currentBase to $targetBlockTypeId rot=${targetRotation.name}")
 
         // Mark/clear must be inside world.execute since setBlock triggers RefSystem synchronously
         world.execute {
@@ -149,7 +148,6 @@ class VisualStateSystem : TickingSystem<ChunkStore>() {
             ) ?: continue
             val blockType = worldChunk.getBlockType(pos) ?: continue
             worldChunk.setBlockInteractionState(pos, blockType, state)
-            println("[VisualStateSystem] $pos -> $state")
         }
 
         dirtyPositions.clear()


### PR DESCRIPTION
Removed verbose debug logging that was generating ~1GB log files.

## Changes
Stripped debug println statements from topology and placement systems, keeping only critical error messages (UNSTABLE convergence failures).

**Before:** 53 println statements  
**After:** 2 println statements (only errors)

## Files Cleaned
- TopologySystem.kt (29 → 2)
- Mux2PlacementSystem.kt (9 → 0)
- BlockChangeEventSystems.kt (7 → 0)
- VisualStateSystem.kt (2 → 0)
- Mux2Control.kt (2 → 0)
- LeverInteractionSystem.kt (2 → 0)
- RelayControl.kt (1 → 0)
- Mux2Topology.kt (1 → 0)

## Impact
- Dramatically reduces log file size
- Improves I/O performance (less disk writes)
- Cleaner console output
- Still logs critical errors (convergence failures)

## Testing
✅ Builds successfully  
✅ Deployed and tested locally