### PR TITLE
fix: Remove debug println statements and standardize logging

### DIFF
--- a/src/main/kotlin/dev/hytalemodding/ExamplePlugin.kt
+++ b/src/main/kotlin/dev/hytalemodding/ExamplePlugin.kt
@@ -56,48 +56,43 @@ class ExamplePlugin(init: JavaPluginInit) : JavaPlugin(init) {
     }
 
     override fun setup() {
-        logger.at(Level.INFO).log("[ExamplePlugin] setup() called - beginning initialization")
+        logger.at(Level.INFO).log("[Grid] setup() called - beginning initialization")
 
-//        this.reactiveChunkComponentType = this.chunkStoreRegistry.registerComponent(ReactiveChunk::class.java, "ReactiveChunk", ReactiveChunk.CODEC)
-//        lampComponentType = this.chunkStoreRegistry.registerComponent(Lamp::class.java, "Lamp", Lamp.CODEC)
-//        logger.at(Level.INFO).log("[ExamplePlugin] ReactiveChunk component registered")
-
-//        this.chunkStoreRegistry.registerSystem(ReactiveBlockInteractSystem(this.reactiveChunkComponentType))
         powerConnectableComponentType = this.chunkStoreRegistry.registerComponent(PowerConnectable::class.java, "PowerConnectable", PowerConnectable.CODEC)
-        logger.at(Level.INFO).log("[ExamplePlugin] PowerConnectable registered")
+        logger.at(Level.INFO).log("[Grid] PowerConnectable registered")
         powerNetIdsComponentType = this.chunkStoreRegistry.registerComponent(PowerNetIds::class.java, "PowerNetIds", PowerNetIds.CODEC)
-        logger.at(Level.INFO).log("[ExamplePlugin] PowerNetIds registered")
+        logger.at(Level.INFO).log("[Grid] PowerNetIds registered")
         powerSourceComponentType = this.chunkStoreRegistry.registerComponent(PowerSource::class.java, "PowerSource", PowerSource.CODEC)
-        logger.at(Level.INFO).log("[ExamplePlugin] PowerSource registered")
+        logger.at(Level.INFO).log("[Grid] PowerSource registered")
         powerWireComponentType = this.chunkStoreRegistry.registerComponent(PowerWire::class.java, "PowerWire", PowerWire.CODEC)
-        logger.at(Level.INFO).log("[ExamplePlugin] PowerWire registered")
+        logger.at(Level.INFO).log("[Grid] PowerWire registered")
         lampComponentType = this.chunkStoreRegistry.registerComponent(Lamp::class.java, "Lamp", Lamp.CODEC)
-        logger.at(Level.INFO).log("[ExamplePlugin] Lamp registered")
+        logger.at(Level.INFO).log("[Grid] Lamp registered")
         inputPortComponentType = this.chunkStoreRegistry.registerComponent(InputPort::class.java, "InputPort", InputPort.CODEC)
-        logger.at(Level.INFO).log("[ExamplePlugin] InputPort registered")
+        logger.at(Level.INFO).log("[Grid] InputPort registered")
         relayComponentType = this.chunkStoreRegistry.registerComponent(Relay::class.java, "Relay", Relay.CODEC)
-        logger.at(Level.INFO).log("[ExamplePlugin] Relay registered")
+        logger.at(Level.INFO).log("[Grid] Relay registered")
         visualStateComponentType = this.chunkStoreRegistry.registerComponent(VisualState::class.java, "VisualState", VisualState.CODEC)
-        logger.at(Level.INFO).log("[ExamplePlugin] VisualState registered")
+        logger.at(Level.INFO).log("[Grid] VisualState registered")
         mux2PartComponentType = this.chunkStoreRegistry.registerComponent(Mux2Part::class.java, "Mux2Part", Mux2Part.CODEC)
-        logger.at(Level.INFO).log("[ExamplePlugin] Mux2Part registered")
+        logger.at(Level.INFO).log("[Grid] Mux2Part registered")
         leverComponentType = this.chunkStoreRegistry.registerComponent(Lever::class.java, "Lever", Lever.CODEC)
-        logger.at(Level.INFO).log("[ExamplePlugin] Lever registered")
+        logger.at(Level.INFO).log("[Grid] Lever registered")
 
         stateChangeQueueType = this.chunkStoreRegistry.registerResource(StateChangeEventQueue::class.java, "StateChangeEventQueue",
             StateChangeEventQueue.CODEC)
-        logger.at(Level.INFO).log("[ExamplePlugin] StateChangeEventQueue resource registered")
+        logger.at(Level.INFO).log("[Grid] StateChangeEventQueue resource registered")
 
         // Register event systems for block place/break
         this.chunkStoreRegistry.registerSystem(PowerBlockAddedSystem())
         logger.at(Level.INFO).log("[Grid] PowerBlockAddedSystem registered")
 
         this.entityStoreRegistry.registerSystem(PowerBlockBreakEvent())
-        logger.at(Level.INFO).log("[ExamplePlugin] PowerBlockBreakEvent registered")
+        logger.at(Level.INFO).log("[Grid] PowerBlockBreakEvent registered")
         
         // Register lever interaction system
         this.entityStoreRegistry.registerSystem(LeverInteractionSystem())
-        logger.at(Level.INFO).log("[ExamplePlugin] LeverInteractionSystem registered")
+        logger.at(Level.INFO).log("[Grid] LeverInteractionSystem registered")
 
         // Register topology system
         this.chunkStoreRegistry.registerSystem(TopologySystem())

--- a/src/main/kotlin/dev/hytalemodding/Source.kt
+++ b/src/main/kotlin/dev/hytalemodding/Source.kt
@@ -120,9 +120,6 @@ fun <T : Component<ChunkStore>> blockIsType(
     return cmdBuf.getComponent(blockRef, type) != null
 }
 
-private var lastBfsLogTime: Long = 0
-private var lastTransportLogTime: Long = 0
-
 data class BfsResult(val sinks: List<Vector3i>, val paths: Map<Vector3i, List<Vector3i>>)
 
 fun <Transport : Component<ChunkStore>, Sink : Component<ChunkStore>> bfs(
@@ -132,12 +129,6 @@ fun <Transport : Component<ChunkStore>, Sink : Component<ChunkStore>> bfs(
     blockComponentChunk: BlockComponentChunk,
     cmdBuf: CommandBuffer<ChunkStore>
 ): BfsResult {
-    val currentTime = System.currentTimeMillis()
-    if (currentTime - lastBfsLogTime >= 5000) {
-        println("BFS running from start position: ${start.x}, ${start.y}, ${start.z}")
-        lastBfsLogTime = currentTime
-    }
-
     var queue = mutableListOf<Vector3i>()
     var visited = mutableListOf<Vector3i>()
     val sinks = mutableListOf<Vector3i>()
@@ -165,13 +156,6 @@ fun <Transport : Component<ChunkStore>, Sink : Component<ChunkStore>> bfs(
         }
 
         val isTransport = blockIsType(current, on, blockComponentChunk, cmdBuf)
-        if (isTransport) {
-            val now = System.currentTimeMillis()
-            if (now - lastTransportLogTime >= 5000) {
-                println("Found connected transport at: ${current.x}, ${current.y}, ${current.z}")
-                lastTransportLogTime = now
-            }
-        }
 
         // Expand from start (source) or from transports
         if (current == start || isTransport) {

--- a/src/main/kotlin/dev/hytalemodding/newnet/VisualStateSystem.kt
+++ b/src/main/kotlin/dev/hytalemodding/newnet/VisualStateSystem.kt
@@ -52,13 +52,9 @@ private fun processWireShapeUpdates(queue: StateChangeEventQueue, world: World, 
         val currentBlockId = currentBlockType.id ?: continue
         if (!isWireBlock(currentBlockId)) continue
 
-        println("[VisualState] Wire at $pos: currentBlock=$currentBlockId, channel=${hasPowerWire.channel}")
-
         // Compute connections and look up target variant (only connects to same-channel wires)
         val connections = getConnections(world, pos, hasPowerWire.channel)
         val result = WireLookupTable.lookup(connections)
-        
-        println("[VisualState]   Connections: U=${connections.up} D=${connections.down} N=${connections.north} E=${connections.east} S=${connections.south} W=${connections.west}")
         
         // Determine wire type suffix based on channel
         val wireType = when (hasPowerWire.channel) {
@@ -71,12 +67,9 @@ private fun processWireShapeUpdates(queue: StateChangeEventQueue, world: World, 
         val targetBlockTypeId = result.getBlockTypeId(wireType)
         val targetRotation = result.yawRotation
 
-        println("[VisualState]   WireType=$wireType, targetBlock=$targetBlockTypeId")
-
         // Check if we already have the correct variant
         val currentBase = currentBlockId.removePrefix("*")
         if (currentBase == targetBlockTypeId) {
-            println("[VisualState]   Already correct variant, skipping")
             continue
         }
 
@@ -85,8 +78,6 @@ private fun processWireShapeUpdates(queue: StateChangeEventQueue, world: World, 
 
         // Save channel value before setBlock destroys the block entity
         val originalChannel = hasPowerWire.channel
-        
-        println("[VisualState]   Swapping: $currentBase -> $targetBlockTypeId (channel=$originalChannel)")
         
         // Mark/clear must be inside world.execute since setBlock triggers RefSystem synchronously
         world.execute {
@@ -98,11 +89,7 @@ private fun processWireShapeUpdates(queue: StateChangeEventQueue, world: World, 
                 // Restore channel value (setBlock creates new block entity with default channel=1)
                 val newPowerWire = worldAccess.getComponent(pos, ExamplePlugin.powerWireComponentType)
                 if (newPowerWire != null) {
-                    println("[VisualState]   Before restore: newChannel=${newPowerWire.channel}")
                     newPowerWire.channel = originalChannel
-                    println("[VisualState]   After restore: newChannel=${newPowerWire.channel}")
-                } else {
-                    println("[VisualState]   ERROR: Could not get PowerWire component after setBlock!")
                 }
                 
                 // Preserve powered visual state if the block had one

--- a/src/main/kotlin/dev/hytalemodding/wire/WireConnectionSystem.kt
+++ b/src/main/kotlin/dev/hytalemodding/wire/WireConnectionSystem.kt
@@ -32,7 +32,6 @@ fun isConnectableAt(world: World, pos: Vector3i, fromFace: Int, sourceChannel: I
     // Check if it's an InputPort (always connectable)
     val inputPort = getComponentForGlobalXyz(world, pos, ExamplePlugin.inputPortComponentType)
     if (inputPort != null) {
-        println("  [Connection] $pos: InputPort (always connectable)")
         return true
     }
     
@@ -47,12 +46,10 @@ fun isConnectableAt(world: World, pos: Vector3i, fromFace: Int, sourceChannel: I
     val neighborWire = getComponentForGlobalXyz(world, pos, ExamplePlugin.powerWireComponentType)
     if (neighborWire != null) {
         val channelMatch = neighborWire.channel == sourceChannel
-        println("  [Connection] $pos: Wire ch=${neighborWire.channel}, source ch=$sourceChannel, match=$channelMatch")
         return channelMatch
     }
     
     // Non-wire components are channel-agnostic
-    println("  [Connection] $pos: PowerConnectable (non-wire), connectable=true")
     return true
 }
 


### PR DESCRIPTION
Fixes #49
Fixes #58
Fixes #59

Cleaned up production code by:
- Removing debug println statements from WireConnectionSystem.kt, VisualStateSystem.kt, and Source.kt
- Removing dead commented-out code in ExamplePlugin.kt
- Standardizing all logging tags to '[Grid]' for consistency throughout the codebase