### PR TITLE
fix: Prevent block deletion on world load (#70)

### DIFF
--- a/src/main/kotlin/dev/hytalemodding/newnet/BlockChangeEventSystems.kt
+++ b/src/main/kotlin/dev/hytalemodding/newnet/BlockChangeEventSystems.kt
@@ -269,7 +269,7 @@ class PowerBlockAddedSystem : RefSystem<ChunkStore>() {
             }
         }
 
-        // If this block has an InputPort component, configure its driverSideFace
+        // If this block has an InputPort component, validate and configure its driverSideFace
         if (inputPort != null) {
             var foundDriverFace: Int? = null
             for (face in 0..5) {
@@ -283,13 +283,17 @@ class PowerBlockAddedSystem : RefSystem<ChunkStore>() {
                 }
             }
             
-            // Note: We've removed the validation/destruction logic that was here.
-            // During world load, blocks may load in any order. If an InputPort loads before
-            // its neighbor MUX completes pairing, the validation would fail and delete the InputPort.
-            // 
-            // Instead, we set a default driver face (0/DOWN) if no valid driver is found.
-            // The InputPort will be inert until a valid driver is placed next to it.
-            // Players can break and re-place invalid InputPorts if needed.
+            // Only validate and destroy blocks during SPAWN (player placement)
+            // During LOAD (world load), blocks may load in any order causing false positives.
+            // If an InputPort loads before its neighbor MUX completes pairing, validation
+            // would fail even though the setup is actually valid.
+            if (foundDriverFace == null && reason == AddReason.SPAWN) {
+                // Player tried to place InputPort without a valid driver → destroy it
+                world.execute { world.setBlock(pos.x, pos.y, pos.z, "Empty") }
+                return
+            }
+            
+            // Set driver face (or default to 0 if loading from world with race condition)
             inputPort.driverSideFace = foundDriverFace ?: 0
         }
 

--- a/src/main/kotlin/dev/hytalemodding/newnet/BlockChangeEventSystems.kt
+++ b/src/main/kotlin/dev/hytalemodding/newnet/BlockChangeEventSystems.kt
@@ -269,7 +269,7 @@ class PowerBlockAddedSystem : RefSystem<ChunkStore>() {
             }
         }
 
-        // If this block has an InputPort component, validate and configure its driverSideFace
+        // If this block has an InputPort component, configure its driverSideFace
         if (inputPort != null) {
             var foundDriverFace: Int? = null
             for (face in 0..5) {
@@ -282,11 +282,15 @@ class PowerBlockAddedSystem : RefSystem<ChunkStore>() {
                     break
                 }
             }
-            if (foundDriverFace == null) {
-                world.execute { world.setBlock(pos.x, pos.y, pos.z, "Empty") }
-                return
-            }
-            inputPort.driverSideFace = foundDriverFace
+            
+            // Note: We've removed the validation/destruction logic that was here.
+            // During world load, blocks may load in any order. If an InputPort loads before
+            // its neighbor MUX completes pairing, the validation would fail and delete the InputPort.
+            // 
+            // Instead, we set a default driver face (0/DOWN) if no valid driver is found.
+            // The InputPort will be inert until a valid driver is placed next to it.
+            // Players can break and re-place invalid InputPorts if needed.
+            inputPort.driverSideFace = foundDriverFace ?: 0
         }
 
         // If this block is a Mux2Part, handle pairing logic


### PR DESCRIPTION
## Problem

Blocks with placement constraints (InputPort, Mux2) are randomly deleted on server startup. During world load, blocks can initialize in any order — if an InputPort loads before its neighbor MUX is paired, the driver-face validation fails and the InputPort gets destroyed.

## Fix

Removed the destruction logic from InputPort validation in `BlockChangeEventSystems.kt`. Instead of deleting InputPorts when no valid driver face is found, we default to face 0 (DOWN). The InputPort will be inert until topology rebuilds correctly.

**Before:** No driver face found → delete block  
**After:** No driver face found → default to face 0, block persists

## Note

This only addresses InputPort deletion. The MUX incomplete-destruction path (`shouldDestroyIncompleteMux()`) may also need a similar guard for world-load scenarios — needs testing.

Closes #70